### PR TITLE
Add autogenerated .idea files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ doc/api/
 *.js_
 *.js.deps
 *.js.map
+
+# Android Studio and IntelliJ
+*.iml
+.idea


### PR DESCRIPTION
When I opened the project in Android Studio, several files were autogenerated. I did a bit of reading up on whether or not to commit them, and it looks like those are good to add to .gitignore.

References:
* https://stackoverflow.com/questions/11124053/accidentally-committed-idea-directory-files-into-git
* https://github.com/github/gitignore/blob/master/Android.gitignore
* https://stackoverflow.com/questions/38590022/should-we-ignore-misc-xml-and-projectfoldername-iml-in-pycharm-idea-folder

I could be wrong on any part of this, though. Still learning 🙂 